### PR TITLE
Update configure-RedHat.yml

### DIFF
--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -23,9 +23,10 @@
     dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
     owner: root
     group: root
-    mode: 0644
+    mode: 0640
   notify: restart apache
   when: apache_create_vhosts | bool
+  no_log: True
   tags:
     - apache
 

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -14,6 +14,7 @@
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
+  no_log: True
   tags:
     - apache
 


### PR DESCRIPTION
Fixes broad permissions for vhosts config.

This file might contain passwords so it should not be world readable. Also these passwords should not end up in the logs.

It only fixes the role for our use case (RedHat) and not for other distributions.